### PR TITLE
Allow API URLs to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ function callback(code, error) {
 travisAfterAll(callback);
 ```
 
+You can override the [API host](https://docs.travis-ci.com/api/) by passing
+a second argument:
+
+```js
+travisAfterAll(callback, {
+    API_HOST: 'https://travis.example.com'
+});
+```
+
 ### General usage
 
 :warning: If you're using this method, please try to keep up with the

--- a/README.md
+++ b/README.md
@@ -119,14 +119,19 @@ function callback(code, error) {
 travisAfterAll(callback);
 ```
 
-You can override the [API host](https://docs.travis-ci.com/api/) by passing
-a second argument:
+Travis Pro and Travis Enterprise require different API hosts and may
+require an access token. You can set these via a second argument:
+
 
 ```js
 travisAfterAll(callback, {
-    API_HOST: 'https://travis.example.com'
+    API_HOST: 'https://travis.example.com',
+    ACCESS_TOKEN: 'my travis access token'
 });
 ```
+
+See https://docs.travis-ci.com/api/ for more information on API hosts
+and how to exchange a GitHub token for a Travis API Token.
 
 ### General usage
 

--- a/lib/travis-after-all.js
+++ b/lib/travis-after-all.js
@@ -16,8 +16,9 @@ var travis = {
     // Travis CI API URLs
     // https://docs.travis-ci.com/api/
 
-    API_BUILD_URL: 'https://api.travis-ci.org/builds/' + parseInt(process.env.TRAVIS_BUILD_ID, 10),
-    API_JOBS_URL: 'https://api.travis-ci.org/jobs/'
+    API_HOST: 'https://api.travis-ci.org/',
+    API_BUILD_PATH: '/builds/' + parseInt(process.env.TRAVIS_BUILD_ID, 10),
+    API_JOBS_PATH: '/jobs/'
 
 
 };
@@ -82,7 +83,7 @@ function generateToken(text, key) {
 }
 
 function getBuildData() {
-     getJSON(travis.API_BUILD_URL, function (data) {
+     getJSON(travis.API_HOST + travis.API_BUILD_PATH, function (data) {
 
          var jobs = data.matrix;
 
@@ -164,7 +165,7 @@ function getJobData(jobList) {
 
         } else {
 
-            getJSON(travis.API_JOBS_URL + currentJob.id, function (data) {
+            getJSON(travis.API_HOST + travis.API_JOBS_PATH + currentJob.id, function (data) {
 
                 var jobLog = data.log;
 
@@ -511,11 +512,12 @@ function handleSuccessfulJob(currentJob, jobs) {
 
 // ---------------------------------------------------------------------
 
-function main(callback) {
+function main(callback, travisOverrides) {
 
     configs.callback = callback;
+    travis.API_HOST = (travisOverrides || {}).API_HOST || travis.API_HOST;
 
-    getJSON(travis.API_JOBS_URL + travis.CURRENT_JOB_ID, function (data) {
+    getJSON(travis.API_HOST + travis.API_JOBS_PATH + travis.CURRENT_JOB_ID, function (data) {
 
         // Write the result of current job in its log if it isn't
         // written already (this needs to be done because there isn't

--- a/lib/travis-after-all.js
+++ b/lib/travis-after-all.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto');
 var https = require('https');
+var parseUrl = require('url').parse;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -18,7 +19,11 @@ var travis = {
 
     API_HOST: 'https://api.travis-ci.org/',
     API_BUILD_PATH: '/builds/' + parseInt(process.env.TRAVIS_BUILD_ID, 10),
-    API_JOBS_PATH: '/jobs/'
+    API_JOBS_PATH: '/jobs/',
+
+    // Travis Access Token
+    // https://docs.travis-ci.com/api/
+    ACCESS_TOKEN: null
 
 
 };
@@ -105,7 +110,15 @@ function getBuildData() {
 
 function getJSON(url, callback) {
 
-    https.get(url, function(response) {
+    var options = parseUrl(url);
+
+    if (travis.ACCESS_TOKEN != null) {
+        options.headers = {
+            Authorization: 'token "' + travis.ACCESS_TOKEN + '"'
+        };
+    }
+
+    https.get(options, function(response) {
 
         var body = '';
 
@@ -515,7 +528,9 @@ function handleSuccessfulJob(currentJob, jobs) {
 function main(callback, travisOverrides) {
 
     configs.callback = callback;
-    travis.API_HOST = (travisOverrides || {}).API_HOST || travis.API_HOST;
+    travisOverrides = travisOverrides || {}
+    travis.API_HOST = travisOverrides.API_HOST || travis.API_HOST;
+    travis.ACCESS_TOKEN = travisOverrides.ACCESS_TOKEN || travis.ACCESS_TOKEN;
 
     getJSON(travis.API_HOST + travis.API_JOBS_PATH + travis.CURRENT_JOB_ID, function (data) {
 


### PR DESCRIPTION
https://docs.travis-ci.com/api/ lists the URLs for various Travis environments. This allows the library consumer to specify the correct URLs for the project's environment.

Closes #6
Closes #14
